### PR TITLE
(fix) refine match wrong param passing

### DIFF
--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -623,8 +623,8 @@ kt_double ScanMatcher::MatchScan(
     Vector2<kt_double> fineSearchResolution(m_pCorrelationGrid->GetResolution(),
       m_pCorrelationGrid->GetResolution());
     bestResponse = CorrelateScan(pScan, rMean, fineSearchOffset, fineSearchResolution,
-        0.5 * m_pMapper->m_pCoarseAngleResolution->GetValue(),
         m_pMapper->m_pFineSearchAngleOffset->GetValue(),
+        0.5 * m_pMapper->m_pCoarseAngleResolution->GetValue(),
         doPenalize, rMean, rCovariance, true);
   }
 


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #601 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | tested only with rosbag laser data |

---

## Description of contribution in a few bullet points
- code from upstream open_karto, accidentally passing the wrong params when doing refine matching, which will crash the code when using an extreme set of params

## Description of documentation updates required from your changes

- no
---

## Future work that may be required in bullet points

- no
